### PR TITLE
check for http client before calling report methods;

### DIFF
--- a/lib/plugins/network/flipper_http_client_request.dart
+++ b/lib/plugins/network/flipper_http_client_request.dart
@@ -134,7 +134,7 @@ class FlipperHttpClientRequest implements HttpClientRequest {
       body: body,
     );
 
-    _flipperNetworkPlugin.reportRequest(requestInfo);
+    _flipperNetworkPlugin?.reportRequest(requestInfo);
     return true;
   }
 }

--- a/lib/plugins/network/flipper_http_client_response.dart
+++ b/lib/plugins/network/flipper_http_client_response.dart
@@ -101,7 +101,7 @@ class FlipperHttpClientResponse extends Stream<List<int>> implements HttpClientR
       body: body,
     );
 
-    _flipperNetworkPlugin.reportResponse(responseInfo);
+    _flipperNetworkPlugin?.reportResponse(responseInfo);
     return true;
   }
 }


### PR DESCRIPTION
This PR adds a way to handle when _flipperNetworkPlugin is null.

---

Context: When running my application's main method async, I was running in to an issue where `reportRequest` method was being called on null. Here is a snippet of the log:

```
[VERBOSE-2:ui_dart_state.cc(148)] Unhandled Exception: NoSuchMethodError: The method 'reportRequest' was called on null.
Receiver: null
Tried calling: reportRequest(Instance of 'RequestInfo')
#0      Object.noSuchMethod (dart:core/runtime/libobject_patch.dart:50:5)
#1      FlipperHttpClientRequest._reportRequest (package:flutter_flipperkit/plugins/network/flipper_http_client_request.dart:137:27)
<asynchronous suspension>
#2      FlipperHttpClientRequest.close (package:flutter_flipperkit/plugins/network/flipper_http_client_request.dart:56:16)
<asynchronous suspension>
#3      _WebSocketImpl.connect.<anonymous closure> (dart:_http/websocket_impl.dart:1042:22)
#4      _rootRunUnary (dart:async/zone.dart:1132:38)
#5      _CustomZone.runUnary (dart:async/zone.dart:1029:19)
#6      _FutureListener.handleValue (dart:async/future_impl.dart:126:18)
#7      Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:639:45)
#8      Future._propagateToListeners (dart:async/future_impl.dart:668<…>
Syncing files to device iPhone Xʀ...
```