### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/lib/plugins/network/flipper_http_client_request.dart
+++ b/lib/plugins/network/flipper_http_client_request.dart
@@ -150,7 +150,7 @@ class FlipperHttpClientRequest implements HttpClientRequest {
 
     try {
       if (!streamController.isClosed) streamController.close();
-      body = await streamController.stream.transform(Utf8Decoder(allowMalformed: false)).join();
+      body = await Utf8Decoder(allowMalformed: false).bind(streamController.stream).join();
     } catch (e) { }
 
     RequestInfo requestInfo = new RequestInfo(

--- a/lib/plugins/network/flipper_http_client_response.dart
+++ b/lib/plugins/network/flipper_http_client_response.dart
@@ -93,7 +93,7 @@ class FlipperHttpClientResponse extends Stream<List<int>> implements HttpClientR
 
     try {
       if (!streamController.isClosed) streamController.close();
-      body = await streamController.stream.transform(Utf8Decoder(allowMalformed: false)).join();
+      body = await Utf8Decoder(allowMalformed: false).bind(streamController.stream).join();
     } catch (e) { }
 
     ResponseInfo responseInfo = new ResponseInfo(


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
