### PR TITLE
Updated FlipperKit version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,8 +32,8 @@ android {
     }
     dependencies {
         releaseImplementation project(':flipper-no-op')
-        debugImplementation 'com.facebook.flipper:flipper:0.81.0'
-        debugImplementation 'com.facebook.flipper:flipper-network-plugin:0.81.0'
+        debugImplementation 'com.facebook.flipper:flipper:0.91.2'
+        debugImplementation 'com.facebook.flipper:flipper-network-plugin:0.91.2'
         debugImplementation 'com.facebook.soloader:soloader:0.10.1'
     }
 }

--- a/ios/flutter_flipperkit.podspec
+++ b/ios/flutter_flipperkit.podspec
@@ -1,4 +1,4 @@
-flipperkit_version = '0.81.0'
+flipperkit_version = '0.91.2'
 
 #
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.


### PR DESCRIPTION
v0.81.0 depends on the 0.30 version of ComponentKit which will not compile using the new Xcode (see https://github.com/facebook/componentkit/issues/962) 
v0.91.2 resolves this problem by relying on ComponentKit 0.31