### PR TITLE
Only create NetworkPlugin if needed

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 29
+    namespace 'org.leanflutter.plugins.flutter_flipperkit'
 
     defaultConfig {
         minSdkVersion 16

--- a/android/flipper-no-op/build.gradle
+++ b/android/flipper-no-op/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.facebook'
     compileSdkVersion 28
 
     defaultConfig {

--- a/android/flipper-no-op/src/main/AndroidManifest.xml
+++ b/android/flipper-no-op/src/main/AndroidManifest.xml
@@ -1,3 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.facebook">
-</manifest>
+<manifest />

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="org.leanflutter.plugins.flutter_flipperkit">
-</manifest>
+<manifest />

--- a/android/src/main/java/org/leanflutter/plugins/flutter_flipperkit/FlutterFlipperkitPlugin.java
+++ b/android/src/main/java/org/leanflutter/plugins/flutter_flipperkit/FlutterFlipperkitPlugin.java
@@ -267,7 +267,10 @@ public class FlutterFlipperkitPlugin implements FlutterPlugin, MethodCallHandler
         SoLoader.init(context.getApplicationContext(), false);
         if (BuildConfig.DEBUG && FlipperUtils.shouldEnableFlipper(context)) {
             flipperClient = AndroidFlipperClient.getInstance(context);
-            networkFlipperPlugin = new NetworkFlipperPlugin();
+            networkFlipperPlugin = flipperClient.getPlugin(NetworkFlipperPlugin.ID);
+            if (networkFlipperPlugin == null) {
+                networkFlipperPlugin = new NetworkFlipperPlugin();
+            }
             sharedPreferencesFlipperPlugin = new SharedPreferencesFlipperPlugin(context, "FlutterSharedPreferences");
 
             flipperDatabaseBrowserPlugin = new FlipperDatabaseBrowserPlugin();


### PR DESCRIPTION
In case of Network plugin created in the native project, I don't want to create the new plugin.